### PR TITLE
Settings

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -155,6 +155,20 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 		// ]);
 	}
 
+	onOpen() {
+		super.onOpen()
+
+		if (this.plugin.settings.selectedTextAsSearch == false) return
+
+		const editor = this.app.workspace.getActiveViewOfType(MarkdownView)?.editor
+		if (editor) {
+			this.inputEl.value = editor.getSelection()
+			
+			// We need to trigger the input event to make the results update
+			this.inputEl.dispatchEvent(new Event("input"))
+		}
+	}
+
 	getItems(): BlockSuggestion[] {
 		return this.blocks;
 	}

--- a/main.ts
+++ b/main.ts
@@ -15,6 +15,7 @@ export default class Blockreffer extends Plugin {
 
 	async onload() {
 		this.loadSettings();
+
 		this.addCommand({
 			id: "open-block-search",
 			name: "Search blocks with references",
@@ -137,7 +138,9 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 		this.blocks = blocks;
 		this.action = action;
 		this.setPlaceholder("Search for ^referenced blocks...");
-		this.limit = 10; // TODO make configurable
+
+
+		this.limit = this.plugin.settings.searchLimit;
 
 		// TODO
 		// this.setInstructions([

--- a/main.ts
+++ b/main.ts
@@ -158,14 +158,14 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 	onOpen() {
 		super.onOpen()
 
-		if (this.plugin.settings.selectedTextAsSearch == false) return
+		if (this.plugin.settings.selectedTextAsSearch == false) return;
 
-		const editor = this.app.workspace.getActiveViewOfType(MarkdownView)?.editor
+		const editor = this.app.workspace.getActiveViewOfType(MarkdownView)?.editor;
 		if (editor) {
-			this.inputEl.value = editor.getSelection()
+			this.inputEl.value = editor.getSelection();
 			
 			// We need to trigger the input event to make the results update
-			this.inputEl.dispatchEvent(new Event("input"))
+			this.inputEl.dispatchEvent(new Event("input"));
 		}
 	}
 
@@ -177,9 +177,9 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 	getItemText(item: BlockSuggestion): string {
 		let toSearch = ""
 
-		if (this.plugin.settings.toSearch.content) toSearch += item.content
-		if (this.plugin.settings.toSearch.path   ) toSearch += item.file.path
-		if (this.plugin.settings.toSearch.id     ) toSearch += item.id
+		if (this.plugin.settings.toSearch.content) toSearch += item.content;
+		if (this.plugin.settings.toSearch.path   ) toSearch += item.file.path;
+		if (this.plugin.settings.toSearch.id     ) toSearch += item.id;
 
 		return toSearch;
 	}
@@ -219,11 +219,11 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 			return fragment;
 		}
 
-		const sansLink = unlinkfy(contentWithoutId)
+		const sansLink = unlinkfy(contentWithoutId);
 		const withLink = document.createDocumentFragment()
-				.appendChild(document.createTextNode(contentWithoutId))
+				.appendChild(document.createTextNode(contentWithoutId));
 
-		const suggestionBlockText = this.plugin.settings.parseLinks ? sansLink : withLink
+		const suggestionBlockText = this.plugin.settings.parseLinks ? sansLink : withLink;
 
 		el.createDiv({ cls: "suggestion-content" }, (contentDiv) => {
 			contentDiv
@@ -234,7 +234,7 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 
 			const from = this.plugin.settings.fileName == "base"
 				? item.file.basename
-				: item.file.path
+				: item.file.path;
 
 			contentDiv.createEl("small", {
 				text: `${from}#^${item.id}`,
@@ -248,13 +248,13 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 			const editor =
 				this.app.workspace.getActiveViewOfType(MarkdownView)?.editor;
 			if (editor) {
-				const selection = editor.getSelection()
+				const selection = editor.getSelection();
 				// Build the block
 				const link = this.plugin.settings.keepText && selection
 					? `[[${item.file.basename}#^${item.id}|${selection}]]`
-					: `[[${item.file.basename}#^${item.id}]]`
+					: `[[${item.file.basename}#^${item.id}]]`;
 
-				const replacement = this.plugin.settings.format.replace("{link}", link)
+				const replacement = this.plugin.settings.format.replace("{link}", link);
 
 				// Embed the block using the ref
 				editor.replaceSelection(replacement);

--- a/main.ts
+++ b/main.ts
@@ -175,7 +175,6 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 			? item.content.replace(`^${item.id}`, "").trim() // cases like https://github.com/tyler-dot-earth/obsidian-blockreffer/issues/5
 			: item.content.trim();
 
-		// TODO make this optional
 		function unlinkfy(text: string): DocumentFragment {
 			const fragment = document.createDocumentFragment();
 			let lastIndex = 0;
@@ -205,15 +204,20 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 
 			return fragment;
 		}
-		const sansLink = unlinkfy(contentWithoutId);
+
+		const sansLink = unlinkfy(contentWithoutId)
+		const withLink = document.createDocumentFragment()
+				.appendChild(document.createTextNode(contentWithoutId))
+
+		const suggestionBlockText = this.plugin.settings.parseLinks ? sansLink : withLink
 
 		el.createDiv({ cls: "suggestion-content" }, (contentDiv) => {
 			contentDiv
 				.createDiv({
-					// text: sansLink,
 					cls: "blockreffer-suggestion-block-text",
 				})
-				.appendChild(sansLink);
+				.appendChild(suggestionBlockText);
+
 			const from = this.plugin.settings.fileName == "base"
 				? item.file.basename
 				: item.file.path

--- a/main.ts
+++ b/main.ts
@@ -177,7 +177,7 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 	getItemText(item: BlockSuggestion): string {
 		let toSearch = ""
 
-		if (this.plugin.settings.toSearch.content) toSearch += item.content;
+		if (this.plugin.settings.toSearch.content) toSearch += item.content.replace(`^${item.id}`, "").trim();
 		if (this.plugin.settings.toSearch.path   ) toSearch += item.file.path;
 		if (this.plugin.settings.toSearch.id     ) toSearch += item.id;
 

--- a/main.ts
+++ b/main.ts
@@ -254,7 +254,7 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 					? `[[${item.file.basename}#^${item.id}|${selection}]]`
 					: `[[${item.file.basename}#^${item.id}]]`;
 
-				const replacement = this.plugin.settings.format.replace("{link}", link);
+				const replacement = this.plugin.settings.format.replace("{backlink}", link);
 
 				// Embed the block using the ref
 				editor.replaceSelection(replacement);

--- a/main.ts
+++ b/main.ts
@@ -171,8 +171,9 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 	}
 
 	renderSuggestion({ item }: FuzzyMatch<BlockSuggestion>, el: HTMLElement) {
-		// TODO make this optional
-		const contentWithoutId = item.content.replace(`^${item.id}`, "").trim(); // cases like https://github.com/tyler-dot-earth/obsidian-blockreffer/issues/5
+		const contentWithoutId = this.plugin.settings.removeIdFromContent
+			? item.content.replace(`^${item.id}`, "").trim() // cases like https://github.com/tyler-dot-earth/obsidian-blockreffer/issues/5
+			: item.content.trim();
 
 		// TODO make this optional
 		function unlinkfy(text: string): DocumentFragment {

--- a/main.ts
+++ b/main.ts
@@ -161,8 +161,13 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 
 	// fuzzy-searchable content
 	getItemText(item: BlockSuggestion): string {
-		// TODO make this configurable maybe?
-		return item.content + item.file.path + item.id;
+		let toSearch = ""
+
+		if (this.plugin.settings.toSearch.content) toSearch += item.content
+		if (this.plugin.settings.toSearch.path   ) toSearch += item.file.path
+		if (this.plugin.settings.toSearch.id     ) toSearch += item.id
+
+		return toSearch;
 	}
 
 	renderSuggestion({ item }: FuzzyMatch<BlockSuggestion>, el: HTMLElement) {

--- a/main.ts
+++ b/main.ts
@@ -234,10 +234,16 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 			const editor =
 				this.app.workspace.getActiveViewOfType(MarkdownView)?.editor;
 			if (editor) {
+				const selection = editor.getSelection()
+				// Build the block
+				const link = this.plugin.settings.keepText && selection
+					? `[[${item.file.basename}#^${item.id}|${selection}]]`
+					: `[[${item.file.basename}#^${item.id}]]`
+
+				const replacement = this.plugin.settings.format.replace("{link}", link)
+
 				// Embed the block using the ref
-				editor.replaceSelection(
-					`![[${item.file.basename}#^${item.id}]]`,
-				);
+				editor.replaceSelection(replacement);
 			}
 		}
 

--- a/main.ts
+++ b/main.ts
@@ -7,8 +7,14 @@ import {
 	TFile,
 } from "obsidian";
 
+import { BlockrefferSettings, DEFAULT_SETTINGS } from "settings/settings"
+import { BlockrefferSettingTab } from "settings/settingsTab"
+
 export default class Blockreffer extends Plugin {
+	settings: BlockrefferSettings;
+
 	async onload() {
+		this.loadSettings();
 		this.addCommand({
 			id: "open-block-search",
 			name: "Search blocks with references",
@@ -46,6 +52,8 @@ export default class Blockreffer extends Plugin {
 				}).open();
 			},
 		});
+
+		this.addSettingTab(new BlockrefferSettingTab(this.app, this));
 	}
 
 	onunload() {}
@@ -89,6 +97,14 @@ export default class Blockreffer extends Plugin {
 		}
 
 		return blockSuggestions;
+	}
+
+	async loadSettings() {
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+	}
+
+	async saveSettings() {
+		await this.saveData(this.settings);
 	}
 }
 

--- a/main.ts
+++ b/main.ts
@@ -214,9 +214,10 @@ class BlockSearchModal extends FuzzySuggestModal<BlockSuggestion> {
 					cls: "blockreffer-suggestion-block-text",
 				})
 				.appendChild(sansLink);
+			const from = this.plugin.settings.fileName == "base"
+				? item.file.basename
+				: item.file.path
 
-			// TODO setting for path vs basename
-			const from = item.file.basename;
 			contentDiv.createEl("small", {
 				text: `${from}#^${item.id}`,
 				cls: "blockreffer-suggestion-block-file",

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -36,7 +36,7 @@ export interface BlockrefferSettings {
 }
 
 export const DEFAULT_SETTINGS: BlockrefferSettings = {
-	format: '!{link}',
+	format: '!{backlink}',
 	keepText: false,
 	parseLinks: true,
 	selectedTextAsSearch: false,

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -1,17 +1,38 @@
 export interface BlockrefferSettings {
-	format: string;                 // Format string for link insert.
-	keepText: boolean;              // Keep selected text as link display text
-	parseLinks: boolean;            // Should we parse links with unlinkfy?
-	selectedTextAsSearch: boolean;  // Use selected text as inital search value
+    /** The format string for inserting a backlink.
+     * @example `!{link}` becomes `![[link]]
+     */
+    format: string;
+
+    /** Whether the selected text should be retained as the link display text. */
+    keepText: boolean;
+
+    /** Whether links should be parsed using the `unlinkfy` method. */
+    parseLinks: boolean;
+
+    /** Uses the selected text as the initial search value. */
+    selectedTextAsSearch: boolean;
+
+    /** Specifies content that should be searched. */
     toSearch: {
-        content: boolean, 
-        path: boolean, 
-        id: boolean
-    };                              // What should we search for inside files
-    searchLimit: number;            // The limit of search results to display
-    removeIdFromContent: boolean;   // Should we remove the ^block-id
-    fileName: string;               // Should we display the file as it's path or it's name. 
-                                    //   Can be "path" or "base"
+        /** Whether to search within file content. */
+        content: boolean;
+
+        /** Whether to search for matches in the file path. */
+        path: boolean;
+
+        /** Whether to search for matches by file ID. */
+        id: boolean;
+    };
+
+    /** Maximum number of search results to display. */
+    searchLimit: number;
+
+    /** Whether to remove `^block-id` from the content. */
+    removeIdFromContent: boolean;
+
+    /** How the file name should be displayed: "path" for full path or "base" for name only. */
+    fileName: "path" | "base";
 }
 
 export const DEFAULT_SETTINGS: BlockrefferSettings = {

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -1,0 +1,30 @@
+export interface BlockrefferSettings {
+	format: string;                 // Format string for link insert.
+	keepText: boolean;              // Keep selected text as link display text
+	parseLinks: boolean;            // Should we parse links with unlinkfy?
+	selectedTextAsSearch: boolean;  // Use selected text as inital search value
+    toSearch: {
+        content: boolean, 
+        path: boolean, 
+        id: boolean
+    };                              // What should we search for inside files
+    searchLimit: number;            // The limit of search results to display
+    removeIdFromContent: boolean;   // Should we remove the ^block-id
+    fileName: string;               // Should we display the file as it's path or it's name. 
+                                    //   Can be "path" or "base"
+}
+
+export const DEFAULT_SETTINGS: BlockrefferSettings = {
+	format: '!{link}',
+	keepText: false,
+	parseLinks: true,
+	selectedTextAsSearch: false,
+    toSearch: {
+        content: true, 
+        path: true, 
+        id: true
+    },
+    searchLimit: 10,
+    removeIdFromContent: true,
+    fileName: "base"
+}

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -47,5 +47,5 @@ export const DEFAULT_SETTINGS: BlockrefferSettings = {
     },
     searchLimit: 10,
     removeIdFromContent: true,
-    fileName: "base"
+    fileName: "base" as const,
 }

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -98,7 +98,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
         
         new Setting(containerEl)
             .setName("File name in result")
-            .setDesc("Do you want the names of the files in the search results to displayed as their/full/path.md or just as their name?")
+            .setDesc("Show just the file's name or the/full/path.md in search results?")
             .addDropdown(dropdown => dropdown
                 .addOption("base", "File name")
                 .addOption("path", "File path")

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -5,6 +5,10 @@ import {
 } from "obsidian";
 
 import Blockreffer from "main";
+import { DEFAULT_SETTINGS } from "./settings";
+
+const formatRegex = /!\{link\}/
+const ERROR_COLOR = "var(--background-modifier-error)"
 
 export class BlockrefferSettingTab extends PluginSettingTab {
 	plugin: Blockreffer;
@@ -30,9 +34,27 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 				.setPlaceholder('!{link}')
 				.setValue(this.plugin.settings.format)
 				.onChange(async (value) => {
-					this.plugin.settings.format = value;
+					// Check if the field contains a !{link}
+					if (formatRegex.test(value)) {
+						text.inputEl.style.borderColor = ""
+					}
+					else {
+						text.inputEl.style.borderColor = ERROR_COLOR
+					}
+
+					// Check if empty and reset to default if it is
+					if (value === "") this.plugin.settings.format = DEFAULT_SETTINGS.format;
+					else			  this.plugin.settings.format = value;
+
 					await this.plugin.saveSettings();
-				}));
+				})
+				.then((text) => {
+					// Check for invalid format on open
+					if (!formatRegex.test(text.getValue())) {
+						text.inputEl.style.borderColor = ERROR_COLOR
+					}
+				})
+			);
 
 		new Setting(containerEl)
 			.setName("Use selected text as link display text")

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -73,6 +73,17 @@ export class BlockrefferSettingTab extends PluginSettingTab {
                 )
 		
 		new Setting(containerEl)
+			.setName("Use selected text as initial search")
+            .setDesc("If true, when you open the search box, the text you have selected will already be searched for.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.selectedTextAsSearch)
+				.onChange(async (value) => {
+					this.plugin.settings.selectedTextAsSearch = value;
+					await this.plugin.saveSettings();
+				})
+			)
+		
+		new Setting(containerEl)
 			.setName("Search limit")
             .setDesc("The number of search results to display.")
 			.addSlider(slider => slider

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -35,5 +35,43 @@ export class BlockrefferSettingTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 })
             )
+		
+        /* === What to search */
+		new Setting(containerEl)
+			.setName("What to search")
+			.setHeading()
+
+		new Setting(containerEl)
+			.setName("Block content")
+            .setDesc("Search for text inside blocks.")
+			.addToggle(toggle => toggle
+                .setValue(this.plugin.settings.toSearch.content)
+                .onChange(async (value) => {
+                    this.plugin.settings.toSearch.content = value
+                    await this.plugin.saveSettings();
+                })
+            )
+
+		new Setting(containerEl)
+			.setName("File path")
+            .setDesc("Search for file names")
+			.addToggle(toggle => toggle
+                .setValue(this.plugin.settings.toSearch.path)
+                .onChange(async (value) => {
+                    this.plugin.settings.toSearch.path = value
+                    await this.plugin.saveSettings();
+                })
+            )
+
+		new Setting(containerEl)
+			.setName("Block id")
+            .setDesc("Search for ^block-ids")
+			.addToggle(toggle => toggle
+                .setValue(this.plugin.settings.toSearch.id)
+                .onChange(async (value) => {
+                    this.plugin.settings.toSearch.id = value
+                    await this.plugin.saveSettings();
+                })
+            )
 	}
 }

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -22,6 +22,17 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setHeading()
 			.setName("Search settings")
+        
+            new Setting(containerEl)
+                .setName("Remove block id from block content")
+                .setDesc("Should the ^block-id text be removed from the block contents in search results (it will still be displayed beneath the block contents).")
+                .addToggle(toggle => toggle
+                    .setValue(this.plugin.settings.removeIdFromContent)
+                    .onChange(async (value) => {
+                        this.plugin.settings.removeIdFromContent = value;
+                        await this.plugin.saveSettings();
+                    })
+                )
 		
 		new Setting(containerEl)
 			.setName("Search limit")

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -149,7 +149,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("File path")
-            .setDesc("Search for file names")
+            .setDesc("Search file path and name.")
 			.addToggle(toggle => toggle
                 .setValue(this.plugin.settings.toSearch.path)
                 .onChange(async (value) => {

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -125,7 +125,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
                 .addOption("base", "File name")
                 .addOption("path", "File path")
                 .setValue(this.plugin.settings.fileName)
-                .onChange(async (value) => {
+                .onChange(async (value: "base" | "path") => {
                     this.plugin.settings.fileName = value
                     await this.plugin.saveSettings()
                 })

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -138,7 +138,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Block content")
-            .setDesc("Search for text inside blocks.")
+            .setDesc("Search text inside blocks.")
 			.addToggle(toggle => toggle
                 .setValue(this.plugin.settings.toSearch.content)
                 .onChange(async (value) => {

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -74,7 +74,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 		
 		new Setting(containerEl)
 			.setName("Use selected text as initial search")
-            .setDesc("If true, when you open the search box, the text you have selected will already be searched for.")
+            .setDesc("If true, selected text will be used when you open the search box.")
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.selectedTextAsSearch)
 				.onChange(async (value) => {

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -2,9 +2,9 @@ import {
 	PluginSettingTab,
 	Setting,
     App
-} from "obsidian"
+} from "obsidian";
 
-import Blockreffer from "main"
+import Blockreffer from "main";
 
 export class BlockrefferSettingTab extends PluginSettingTab {
 	plugin: Blockreffer;
@@ -48,7 +48,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
         /* === Search settings === */
 		new Setting(containerEl)
 			.setHeading()
-			.setName("Search settings")
+			.setName("Search settings");
 
 		new Setting(containerEl)
 			.setName("Parse links")
@@ -59,7 +59,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 					this.plugin.settings.parseLinks = value;
 					await this.plugin.saveSettings();
 				})
-			)
+			);
         
             new Setting(containerEl)
                 .setName("Remove block id from block content")
@@ -70,7 +70,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
                         this.plugin.settings.removeIdFromContent = value;
                         await this.plugin.saveSettings();
                     })
-                )
+                );
 		
 		new Setting(containerEl)
 			.setName("Use selected text as initial search")
@@ -81,7 +81,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 					this.plugin.settings.selectedTextAsSearch = value;
 					await this.plugin.saveSettings();
 				})
-			)
+			);
 		
 		new Setting(containerEl)
 			.setName("Search limit")
@@ -94,7 +94,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
                     this.plugin.settings.searchLimit = value
                     await this.plugin.saveSettings();
                 })
-            )
+            );
         
         new Setting(containerEl)
             .setName("File name in result")
@@ -107,12 +107,12 @@ export class BlockrefferSettingTab extends PluginSettingTab {
                     this.plugin.settings.fileName = value
                     await this.plugin.saveSettings()
                 })
-            )
+            );
 		
         /* === What to search */
 		new Setting(containerEl)
 			.setName("What to search")
-			.setHeading()
+			.setHeading();
 
 		new Setting(containerEl)
 			.setName("Block content")
@@ -123,7 +123,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
                     this.plugin.settings.toSearch.content = value
                     await this.plugin.saveSettings();
                 })
-            )
+            );
 
 		new Setting(containerEl)
 			.setName("File path")
@@ -134,7 +134,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
                     this.plugin.settings.toSearch.path = value
                     await this.plugin.saveSettings();
                 })
-            )
+            );
 
 		new Setting(containerEl)
 			.setName("Block id")
@@ -145,6 +145,6 @@ export class BlockrefferSettingTab extends PluginSettingTab {
                     this.plugin.settings.toSearch.id = value
                     await this.plugin.saveSettings();
                 })
-            )
+            );
 	}
 }

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -18,6 +18,33 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 		const {containerEl} = this;
 
 		containerEl.empty();
+
+		new Setting(containerEl)
+			.setHeading()
+			.setName("How do you want your link?");
+
+		new Setting(containerEl)
+			.setName('Link format')
+			.setDesc('How your link will be inserted into the document. Use {link} as a placeholder for the actual link.')
+			.addText(text => text
+				.setPlaceholder('!{link}')
+				.setValue(this.plugin.settings.format)
+				.onChange(async (value) => {
+					this.plugin.settings.format = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName("Use selected text as link display text")
+            .setDesc("If true, will use the text you have selected as the display text for the link (the bit that goes after the | symbol).")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.keepText)
+				.onChange(async (value) => {
+					this.plugin.settings.keepText = value;
+					await this.plugin.saveSettings();
+				})
+			);
+		
         /* === Search settings === */
 		new Setting(containerEl)
 			.setHeading()

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -7,7 +7,7 @@ import {
 import Blockreffer from "main";
 import { DEFAULT_SETTINGS } from "./settings";
 
-const formatRegex = /!\{backlink\}/
+const formatRegex = /\{backlink\}/
 const ERROR_COLOR = "var(--background-modifier-error)"
 
 export class BlockrefferSettingTab extends PluginSettingTab {
@@ -34,7 +34,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 				.setPlaceholder('!{backlink}')
 				.setValue(this.plugin.settings.format)
 				.onChange(async (value) => {
-					// Check if the field contains a !{backlink}
+					// Check if the field contains a {backlink}
 					if (formatRegex.test(value)) {
 						text.inputEl.style.borderColor = ""
 					}

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -63,7 +63,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
         
             new Setting(containerEl)
                 .setName("Remove block id from block content")
-                .setDesc("Should the ^block-id text be removed from the block contents in search results (it will still be displayed beneath the block contents).")
+                .setDesc("Do not display the ^block-id in search results. It will still be displayed beneath the block content.")
                 .addToggle(toggle => toggle
                     .setValue(this.plugin.settings.removeIdFromContent)
                     .onChange(async (value) => {

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -46,6 +46,19 @@ export class BlockrefferSettingTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 })
             )
+        
+        new Setting(containerEl)
+            .setName("File name in result")
+            .setDesc("Do you want the names of the files in the search results to displayed as their/full/path.md or just as their name?")
+            .addDropdown(dropdown => dropdown
+                .addOption("base", "File name")
+                .addOption("path", "File path")
+                .setValue(this.plugin.settings.fileName)
+                .onChange(async (value) => {
+                    this.plugin.settings.fileName = value
+                    await this.plugin.saveSettings()
+                })
+            )
 		
         /* === What to search */
 		new Setting(containerEl)

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -28,8 +28,8 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 			.setName("How do you want your link?");
 
 		new Setting(containerEl)
-			.setName('Link format')
-			.setDesc('How your link will be inserted into the document. Use {link} as a placeholder for the actual link.')
+			.setName('Backlink format')
+			.setDesc('How your backlink will be inserted into the document. Use {link} as a placeholder for the actual backlink.')
 			.addText(text => text
 				.setPlaceholder('!{link}')
 				.setValue(this.plugin.settings.format)

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -36,7 +36,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Use selected text as link display text")
-            .setDesc("If true, will use the text you have selected as the display text for the link (the bit that goes after the | symbol).")
+            .setDesc("Use selected text as the link alias (the bit that goes after the | symbol).")
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.keepText)
 				.onChange(async (value) => {

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -7,7 +7,7 @@ import {
 import Blockreffer from "main";
 import { DEFAULT_SETTINGS } from "./settings";
 
-const formatRegex = /!\{link\}/
+const formatRegex = /!\{backlink\}/
 const ERROR_COLOR = "var(--background-modifier-error)"
 
 export class BlockrefferSettingTab extends PluginSettingTab {
@@ -25,16 +25,16 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setHeading()
-			.setName("How do you want your link?");
+			.setName("How do you want your backlink?");
 
 		new Setting(containerEl)
 			.setName('Backlink format')
-			.setDesc('How your backlink will be inserted into the document. Use {link} as a placeholder for the actual backlink.')
+			.setDesc('How your backlink will be inserted into the document. Use {backlink} as a placeholder for the actual backlink.')
 			.addText(text => text
-				.setPlaceholder('!{link}')
+				.setPlaceholder('!{backlink}')
 				.setValue(this.plugin.settings.format)
 				.onChange(async (value) => {
-					// Check if the field contains a !{link}
+					// Check if the field contains a !{backlink}
 					if (formatRegex.test(value)) {
 						text.inputEl.style.borderColor = ""
 					}
@@ -57,8 +57,8 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
-			.setName("Use selected text as link display text")
-            .setDesc("Use selected text as the link alias (the bit that goes after the | symbol).")
+			.setName("Use selected text as backlink display text")
+            .setDesc("Use selected text as the backlink alias (the bit that goes after the | symbol).")
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.keepText)
 				.onChange(async (value) => {

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -22,6 +22,17 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setHeading()
 			.setName("Search settings")
+
+		new Setting(containerEl)
+			.setName("Parse links")
+            .setDesc("Should markdown links be displayed as just their display text in search results?")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.parseLinks)
+				.onChange(async (value) => {
+					this.plugin.settings.parseLinks = value;
+					await this.plugin.saveSettings();
+				})
+			)
         
             new Setting(containerEl)
                 .setName("Remove block id from block content")

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -18,5 +18,22 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 		const {containerEl} = this;
 
 		containerEl.empty();
+        /* === Search settings === */
+		new Setting(containerEl)
+			.setHeading()
+			.setName("Search settings")
+		
+		new Setting(containerEl)
+			.setName("Search limit")
+            .setDesc("The number of search results to display.")
+			.addSlider(slider => slider
+                .setLimits(1,50,1)
+                .setValue(this.plugin.settings.searchLimit)
+                .setDynamicTooltip()
+                .onChange(async (value) => {
+                    this.plugin.settings.searchLimit = value
+                    await this.plugin.saveSettings();
+                })
+            )
 	}
 }

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -1,0 +1,22 @@
+import {
+	PluginSettingTab,
+	Setting,
+    App
+} from "obsidian"
+
+import Blockreffer from "main"
+
+export class BlockrefferSettingTab extends PluginSettingTab {
+	plugin: Blockreffer;
+
+	constructor(app: App, plugin: Blockreffer) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		const {containerEl} = this;
+
+		containerEl.empty();
+	}
+}

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -160,7 +160,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Block id")
-            .setDesc("Search for ^block-ids")
+            .setDesc("Search ^block-ids.")
 			.addToggle(toggle => toggle
                 .setValue(this.plugin.settings.toSearch.id)
                 .onChange(async (value) => {

--- a/settings/settingsTab.ts
+++ b/settings/settingsTab.ts
@@ -109,7 +109,7 @@ export class BlockrefferSettingTab extends PluginSettingTab {
                 })
             );
 		
-        /* === What to search */
+        /* === What to search === */
 		new Setting(containerEl)
 			.setName("What to search")
 			.setHeading();


### PR DESCRIPTION
This pull request adds settings for all the items marked as `//TODO` as well as some quality of life settings of my own. Users can now specify
- How many blocks to display in the search results
- Which of a blocks contents, file name or block ids should be indexed by the search
- If to remove the actual ^block-id text from the block contents in search results
- Whether to display file names as their full path or just their base name
- Whether or not to parse markdown links in block contents
- The format of the inserted reference, which defaults to `!{link}`
- If the selected text should be used as the display text for the reference link
- If to use the selected text as the initial search query when search is opened

<details>
<summary>📸 Here's a screenshot of the settings menu</summary>
<br>
<div align="center">
  <img width="500" alt="Screenshot 2024-10-22 at 03 51 49" src="https://github.com/user-attachments/assets/1f5b3223-820a-4e0b-a31c-394097e69818">
</div>
</details

I tried to follow the style of the current code but I may have missed some semicolons hehe.

Best,
Erica 🧡